### PR TITLE
Ejercicio shared preferences

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -42,6 +42,9 @@ dependencies {
     implementation(libs.material)
     implementation(libs.androidx.activity)
     implementation(libs.androidx.constraintlayout)
+
+    implementation (libs.gson)
+
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/edu/iesam/examaad1eval/MainActivity.kt
+++ b/app/src/main/java/edu/iesam/examaad1eval/MainActivity.kt
@@ -1,7 +1,11 @@
 package edu.iesam.examaad1eval
 
 import android.os.Bundle
+import android.util.Log
 import androidx.appcompat.app.AppCompatActivity
+import edu.iesam.examaad1eval.features.ex1.data.Ex1DataRepository
+import edu.iesam.examaad1eval.features.ex1.data.local.Ex1XmlLocalDataSource
+import edu.iesam.examaad1eval.features.ex1.data.remote.MockEx1RemoteDataSource
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
@@ -15,7 +19,14 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun executeExercise1(){
-        //Ejecutar el ejercicio 1 desde aquí llamando al Ex1DataRepository directamente
+        val dataRepo= Ex1DataRepository(
+            MockEx1RemoteDataSource(),
+            Ex1XmlLocalDataSource(this)
+        )
+
+        Log.d("Users", dataRepo.getUsers().toString())
+        Log.d("Items", dataRepo.getItems().toString())
+        Log.d("Services", dataRepo.getServices().toString())
     }
 
     @OptIn(DelicateCoroutinesApi::class)

--- a/app/src/main/java/edu/iesam/examaad1eval/MainActivity.kt
+++ b/app/src/main/java/edu/iesam/examaad1eval/MainActivity.kt
@@ -24,9 +24,9 @@ class MainActivity : AppCompatActivity() {
             Ex1XmlLocalDataSource(this)
         )
 
-        Log.d("Users", dataRepo.getUsers().toString())
-        Log.d("Items", dataRepo.getItems().toString())
-        Log.d("Services", dataRepo.getServices().toString())
+        Log.d("@Dev", dataRepo.getUsers().toString())
+        Log.d("@Dev", dataRepo.getItems().toString())
+        Log.d("@Dev", dataRepo.getServices().toString())
     }
 
     @OptIn(DelicateCoroutinesApi::class)

--- a/app/src/main/java/edu/iesam/examaad1eval/features/ex1/Ex1Repository.kt
+++ b/app/src/main/java/edu/iesam/examaad1eval/features/ex1/Ex1Repository.kt
@@ -1,5 +1,9 @@
 package edu.iesam.examaad1eval.features.ex1
 
+import edu.iesam.examaad1eval.features.ex1.domain.Item
+import edu.iesam.examaad1eval.features.ex1.domain.Services
+import edu.iesam.examaad1eval.features.ex1.domain.User
+
 interface Ex1Repository {
     fun getUsers(): List<User>
     fun getItems(): List<Item>

--- a/app/src/main/java/edu/iesam/examaad1eval/features/ex1/data/Ex1DataRepository.kt
+++ b/app/src/main/java/edu/iesam/examaad1eval/features/ex1/data/Ex1DataRepository.kt
@@ -1,0 +1,46 @@
+package edu.iesam.examaad1eval.features.ex1.data
+
+import edu.iesam.examaad1eval.features.ex1.Ex1Repository
+import edu.iesam.examaad1eval.features.ex1.data.local.Ex1XmlLocalDataSource
+import edu.iesam.examaad1eval.features.ex1.data.remote.MockEx1RemoteDataSource
+import edu.iesam.examaad1eval.features.ex1.domain.Item
+import edu.iesam.examaad1eval.features.ex1.domain.Services
+import edu.iesam.examaad1eval.features.ex1.domain.User
+
+class Ex1DataRepository(
+    private val remoteDataSource: MockEx1RemoteDataSource,
+    private val localDataSource: Ex1XmlLocalDataSource
+): Ex1Repository {
+    override fun getUsers(): List<User> {
+        val users = localDataSource.getUsers()
+        if (users.isEmpty()) {
+            val usersFromRemote = remoteDataSource.getUsers()
+            localDataSource.saveUsers(usersFromRemote)
+            return usersFromRemote
+        }else{
+            return users
+        }
+    }
+
+    override fun getItems(): List<Item> {
+        val items = localDataSource.getItems()
+        if (items.isEmpty()) {
+            val itemsFromRemote = remoteDataSource.getItems()
+            localDataSource.saveItems(itemsFromRemote)
+            return itemsFromRemote
+        }else{
+            return items
+        }
+    }
+
+    override fun getServices(): List<Services> {
+        val services = localDataSource.getServices()
+        if (services.isEmpty()) {
+            val servicesFromRemote = remoteDataSource.getServices()
+            localDataSource.saveServices(servicesFromRemote)
+            return servicesFromRemote
+        }else{
+            return services
+        }
+    }
+}

--- a/app/src/main/java/edu/iesam/examaad1eval/features/ex1/data/Ex1DataRepository.kt
+++ b/app/src/main/java/edu/iesam/examaad1eval/features/ex1/data/Ex1DataRepository.kt
@@ -33,14 +33,14 @@ class Ex1DataRepository(
         }
     }
 
-    override fun getServices(): List<Services> {
-        val services = localDataSource.getServices()
-        if (services.isEmpty()) {
-            val servicesFromRemote = remoteDataSource.getServices()
-            localDataSource.saveServices(servicesFromRemote)
-            return servicesFromRemote
-        }else{
-            return services
+   override fun getServices(): List<Services> {
+       val services = localDataSource.getServices()
+       if (services.isEmpty()) {
+           val servicesFromRemote = remoteDataSource.getServices()
+           localDataSource.saveServices(servicesFromRemote)
+           return servicesFromRemote
+       } else {
+           return services
         }
     }
 }

--- a/app/src/main/java/edu/iesam/examaad1eval/features/ex1/data/local/Ex1XmlLocalDataSource.kt
+++ b/app/src/main/java/edu/iesam/examaad1eval/features/ex1/data/local/Ex1XmlLocalDataSource.kt
@@ -16,26 +16,21 @@ class Ex1XmlLocalDataSource(private val context: Context) {
         context.getString(R.string.ex1), Context.MODE_PRIVATE
     )
 
-    fun saveUsers(users: List<User>) {
-        sharedPref.edit {
-            users.forEach {
-                putString(it.id, gson.toJson(it))
-            }
-        }
-    }
-
     fun getUsers(): List<User> {
         val users = mutableListOf<User>()
         sharedPref.all.values.forEach {
-            users.add(gson.fromJson(it as String, User::class.java))
+            when(gson.fromJson(it.toString(), User::class.java)){
+                is User -> users.add(gson.fromJson(it as String, User::class.java))
+            }
         }
         return users
     }
 
-    fun saveItems(items: List<Item>) {
+    fun saveUsers(users: List<User>) {
         sharedPref.edit {
-            items.forEach {
-                putString(it.id, gson.toJson(it))
+            users.forEach {
+                putString("usersId ${it.id}", gson.toJson(it))
+                apply()
             }
         }
     }
@@ -43,15 +38,18 @@ class Ex1XmlLocalDataSource(private val context: Context) {
     fun getItems(): List<Item> {
         val items = mutableListOf<Item>()
         sharedPref.all.values.forEach {
-            items.add(gson.fromJson(it as String, Item::class.java))
+            when(gson.fromJson(it as String, Item::class.java)){
+                is Item -> items.add(gson.fromJson(it, Item::class.java))
+            }
         }
         return items
     }
 
-    fun saveServices(services: List<Services>) {
+    fun saveItems(items: List<Item>) {
         sharedPref.edit {
-            services.forEach {
-                putString(it.id, gson.toJson(it))
+            items.forEach {
+                putString("itemsId ${it.id}", gson.toJson(items))
+                apply()
             }
         }
     }
@@ -59,8 +57,19 @@ class Ex1XmlLocalDataSource(private val context: Context) {
     fun getServices(): List<Services> {
         val services = mutableListOf<Services>()
         sharedPref.all.values.forEach {
-            services.add(gson.fromJson(it as String, Services::class.java))
+            when(gson.fromJson(it as String , Services::class.java)){
+                is Services -> services.add(gson.fromJson(it, Services::class.java))
+            }
         }
         return services
+    }
+
+    fun saveServices(services: List<Services>) {
+        sharedPref.edit {
+            services.forEach {
+                putString("servicesId ${it.id}", gson.toJson(it))
+                apply()
+            }
+        }
     }
 }

--- a/app/src/main/java/edu/iesam/examaad1eval/features/ex1/data/local/Ex1XmlLocalDataSource.kt
+++ b/app/src/main/java/edu/iesam/examaad1eval/features/ex1/data/local/Ex1XmlLocalDataSource.kt
@@ -10,66 +10,61 @@ import edu.iesam.examaad1eval.features.ex1.domain.User
 
 class Ex1XmlLocalDataSource(private val context: Context) {
 
+
+
     private val gson = Gson()
 
     private val sharedPref = context.getSharedPreferences(
         context.getString(R.string.ex1), Context.MODE_PRIVATE
     )
 
-    fun getUsers(): List<User> {
-        val users = mutableListOf<User>()
-        sharedPref.all.values.forEach {
-            when(gson.fromJson(it.toString(), User::class.java)){
-                is User -> users.add(gson.fromJson(it as String, User::class.java))
-            }
-        }
-        return users
-    }
 
     fun saveUsers(users: List<User>) {
         sharedPref.edit {
-            users.forEach {
-                putString("usersId ${it.id}", gson.toJson(it))
+                putString("users", gson.toJson(users))
                 apply()
-            }
         }
     }
+
+    fun getUsers(): List<User> {
+        val json = sharedPref.getString("users", null)
+        return if (json != null) {
+            gson.fromJson(json, Array<User>::class.java).toList()
+        } else {
+            emptyList()
+        }
+    }
+
+   fun saveItems(items: List<Item>) {
+        sharedPref.edit {
+            putString("items", gson.toJson(items))
+            apply()
+        }
+   }
 
     fun getItems(): List<Item> {
-        val items = mutableListOf<Item>()
-        sharedPref.all.values.forEach {
-            when(gson.fromJson(it as String, Item::class.java)){
-                is Item -> items.add(gson.fromJson(it, Item::class.java))
-            }
+        val json = sharedPref.getString("items", null)
+        return if (json != null) {
+            gson.fromJson(json, Array<Item>::class.java).toList()
+        } else {
+            emptyList()
         }
-        return items
-    }
-
-    fun saveItems(items: List<Item>) {
-        sharedPref.edit {
-            items.forEach {
-                putString("itemsId ${it.id}", gson.toJson(items))
-                apply()
-            }
-        }
-    }
-
-    fun getServices(): List<Services> {
-        val services = mutableListOf<Services>()
-        sharedPref.all.values.forEach {
-            when(gson.fromJson(it as String , Services::class.java)){
-                is Services -> services.add(gson.fromJson(it, Services::class.java))
-            }
-        }
-        return services
     }
 
     fun saveServices(services: List<Services>) {
         sharedPref.edit {
-            services.forEach {
-                putString("servicesId ${it.id}", gson.toJson(it))
-                apply()
-            }
+            putString("services", gson.toJson(services))
+            apply()
         }
     }
+
+    fun getServices(): List<Services> {
+        val json = sharedPref.getString("services", null)
+        return if (json != null) {
+            gson.fromJson(json, Array<Services>::class.java).toList()
+        } else {
+            emptyList()
+        }
+    }
+
 }

--- a/app/src/main/java/edu/iesam/examaad1eval/features/ex1/data/local/Ex1XmlLocalDataSource.kt
+++ b/app/src/main/java/edu/iesam/examaad1eval/features/ex1/data/local/Ex1XmlLocalDataSource.kt
@@ -1,0 +1,66 @@
+package edu.iesam.examaad1eval.features.ex1.data.local
+
+import android.content.Context
+import androidx.core.content.edit
+import com.google.gson.Gson
+import edu.iesam.examaad1eval.R
+import edu.iesam.examaad1eval.features.ex1.domain.Item
+import edu.iesam.examaad1eval.features.ex1.domain.Services
+import edu.iesam.examaad1eval.features.ex1.domain.User
+
+class Ex1XmlLocalDataSource(private val context: Context) {
+
+    private val gson = Gson()
+
+    private val sharedPref = context.getSharedPreferences(
+        context.getString(R.string.ex1), Context.MODE_PRIVATE
+    )
+
+    fun saveUsers(users: List<User>) {
+        sharedPref.edit {
+            users.forEach {
+                putString(it.id, gson.toJson(it))
+            }
+        }
+    }
+
+    fun getUsers(): List<User> {
+        val users = mutableListOf<User>()
+        sharedPref.all.values.forEach {
+            users.add(gson.fromJson(it as String, User::class.java))
+        }
+        return users
+    }
+
+    fun saveItems(items: List<Item>) {
+        sharedPref.edit {
+            items.forEach {
+                putString(it.id, gson.toJson(it))
+            }
+        }
+    }
+
+    fun getItems(): List<Item> {
+        val items = mutableListOf<Item>()
+        sharedPref.all.values.forEach {
+            items.add(gson.fromJson(it as String, Item::class.java))
+        }
+        return items
+    }
+
+    fun saveServices(services: List<Services>) {
+        sharedPref.edit {
+            services.forEach {
+                putString(it.id, gson.toJson(it))
+            }
+        }
+    }
+
+    fun getServices(): List<Services> {
+        val services = mutableListOf<Services>()
+        sharedPref.all.values.forEach {
+            services.add(gson.fromJson(it as String, Services::class.java))
+        }
+        return services
+    }
+}

--- a/app/src/main/java/edu/iesam/examaad1eval/features/ex1/data/remote/MockEx1RemoteDataSource.kt
+++ b/app/src/main/java/edu/iesam/examaad1eval/features/ex1/data/remote/MockEx1RemoteDataSource.kt
@@ -1,4 +1,8 @@
-package edu.iesam.examaad1eval.features.ex1
+package edu.iesam.examaad1eval.features.ex1.data.remote
+
+import edu.iesam.examaad1eval.features.ex1.domain.Item
+import edu.iesam.examaad1eval.features.ex1.domain.Services
+import edu.iesam.examaad1eval.features.ex1.domain.User
 
 class MockEx1RemoteDataSource {
 

--- a/app/src/main/java/edu/iesam/examaad1eval/features/ex1/domain/Ex1Models.kt
+++ b/app/src/main/java/edu/iesam/examaad1eval/features/ex1/domain/Ex1Models.kt
@@ -1,4 +1,4 @@
-package edu.iesam.examaad1eval.features.ex1
+package edu.iesam.examaad1eval.features.ex1.domain
 
 data class User(val id: String, val name: String, val surname: String)
 data class Item(val id: String, val name: String, val price: Double)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">ExamAAD1Eval</string>
+    <string name="ex1">ex1</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 agp = "8.6.0"
+gson = "2.11.0"
 kotlin = "1.9.0"
 coreKtx = "1.15.0"
 junit = "4.13.2"
@@ -12,6 +13,7 @@ constraintlayout = "2.2.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }


### PR DESCRIPTION
Se implementa, en el mismo xml 3 tipos de objetos.
El ejercicio pide pedir de local, si hay datos devolverlos, si no, pedir a remoto y guardar en local y devolver remoto

[Fotos]
![image](https://github.com/user-attachments/assets/a2e4689a-da87-4dfe-9056-965bc3c43ac3)
![image](https://github.com/user-attachments/assets/1881c3c4-188b-4e75-8021-178262078eb7)

